### PR TITLE
Cleaning config and explained tests

### DIFF
--- a/tests/functional/index.js
+++ b/tests/functional/index.js
@@ -9,7 +9,9 @@ define([
         name: 'index',
 
         'text test': function () {
-            
+            /*
+            When the homepage loads without a login, USD should display as the default currency
+            */
             return this.remote
                 .get(url)
                 .setFindTimeout(5000)
@@ -21,7 +23,9 @@ define([
                 });
         },
         'element visible test': function () {
-            
+            /*
+            When the homepage loads without a login, the main logo should be visible
+            */
             return this.remote
                 .get(url)
                 .setFindTimeout(5000)
@@ -33,6 +37,9 @@ define([
                 });
         },
         'chaining tests': function () {
+            /*
+            When the homepage loads without a login and the Furniture category is clicked, 'Furniture' should display as the final breadcrumb
+            */
             return this.remote
                 .get(url)
                 .setFindTimeout(5000)
@@ -54,6 +61,9 @@ define([
                 });
         },
         'search input test': function () {
+            /*
+            When the homepage loads without a login and 'watch' is entered into the search box and the enter button is pressed, the results header title should display 'X results for "watch"'
+            */
             return this.remote
                 .get(url)
                 .setFindTimeout(5000)

--- a/tests/intern-local.js
+++ b/tests/intern-local.js
@@ -1,61 +1,29 @@
-// Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
-// These default settings work OK for most people. The options that *must* be changed below are the
-// packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
 define({
-	// The port on which the instrumenting proxy will listen
 	proxyPort: 9000,
 
-	// A fully qualified URL to the Intern proxy
 	proxyUrl: 'localhost:9000',
 
-	// Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
-	// specified browser environments in the `environments` array below as well. See
-	// https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
-	// https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
-	// Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
-	// automatically
 	capabilities: {
 		'selenium-version': '2.44.0'
 	},
 
-	// Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
-	// OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
-	// capabilities options specified for an environment will be copied as-is
 	environments: [
-        {browserName: 'firefox', version: '25'},
+        //{browserName: 'firefox', version: '25'},
         //{browserName: 'chrome'},
         {browserName: 'safari', version: '8.0.2'}
 	],
 
-	// Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
 	maxConcurrency: 3,
     
     reporters: [ 'pretty', 'runner' ],
-
-	// Name of the tunnel class to use for WebDriver tests
-	tunnel: 'nullTunnel',
     
-	// The desired AMD loader to use when running unit tests (client.html/client.js). Omit to use the default Dojo
-	// loader
-	useLoader: {
-		'host-node': 'dojo/dojo',
-		'host-browser': 'node_modules/dojo/dojo.js'
-	},
-
-	// Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
-	// can be used here
-	loader: {
-		// Packages that should be registered with the loader in each testing environment
-	},
+	tunnel: 'nullTunnel',
     
     useSauceConnect: false,
 
-	// Non-functional test suite(s) to run in each browser
 	suites: null,
 
-	// Functional test suite(s) to run in each browser once non-functional tests are completed
 	functionalSuites: [ 'tests/functional/index' ],
 
-	// A regular expression matching URLs to files that should not be included in code coverage analysis
 	excludeInstrumentation: /^(?:tests|node_modules)\//
 });


### PR DESCRIPTION
Removed pre-built elements from intern-local.js to clean file.  Added
temporary descriptors as comments to tests.
